### PR TITLE
use lts-slim instead of lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:lts-slim
 
-RUN apk add --no-cache git
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install git
+
 RUN npm --version
 
 # The docker container is run without network access, so dont check for updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ ENV NO_UPDATE_NOTIFIER=true
 
 WORKDIR /opt/test-runner
 COPY . .
-RUN npm install
+RUN npm ci
 RUN npm run build
 RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g
 RUN npm install @abaplint/runtime -g
-RUN npm list -g
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts
 
 RUN apk add --no-cache git
 RUN npm --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
 RUN apk add --no-cache git
+RUN npm config set update-notifier false
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:current-alpine
 
 RUN apk add --no-cache git
 RUN npm --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:lts
+FROM node:lts-slim
 
+RUN apk add --no-cache git
 RUN npm --version
 
 # The docker container is run without network access, so dont check for updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN npm run build
 RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g
 RUN npm install @abaplint/runtime -g
+RUN npm list -g
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN npm --version
 
 # The docker container is run without network access, so dont check for updates
 ENV NO_UPDATE_NOTIFIER=true
+RUN echo 127.0.0.1   registry.npmjs.org >> /etc/hosts
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g
 RUN npm install @abaplint/runtime -g
 RUN npm list -g
-ENTRYPOINT ["/bin/sh", "-c" , "echo 127.0.0.1   registry.npmjs.org >> /etc/hosts && /opt/test-runner/bin/run.sh"]
+ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NO_UPDATE_NOTIFIER=true
 
 WORKDIR /opt/test-runner
 COPY . .
-RUN npm ci
+RUN npm install
 RUN npm run build
 RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:lts-slim
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get -y install git
+RUN apt-get purge --auto-remove
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
 
 RUN npm --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:lts
 
-RUN apk add --no-cache git
 RUN npm --version
 
 # The docker container is run without network access, so dont check for updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM node:lts-alpine
 
 RUN apk add --no-cache git
-RUN npm install -g npm
 
 # The docker container is run without network access, so dont check for updates
-ENV NO_UPDATE_NOTIFIER true
+ENV NO_UPDATE_NOTIFIER=true
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
 RUN apk add --no-cache git
+RUN npm install -g npm
 
 # The docker container is run without network access, so dont check for updates
 ENV NO_UPDATE_NOTIFIER true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:lts-slim
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get -y install git
-RUN apt-get purge --auto-remove
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:lts-alpine
 
 RUN apk add --no-cache git
-RUN npm config set update-notifier false
+
+# The docker container is run without network access, so dont check for updates
+RUN npm config set -g update-notifier false
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g
 RUN npm install @abaplint/runtime -g
 RUN npm list -g
-ENTRYPOINT ["echo 127.0.0.1   registry.npmjs.org >> /etc/hosts && /opt/test-runner/bin/run.sh"]
+ENTRYPOINT ["/bin/sh", "-c" , "echo 127.0.0.1   registry.npmjs.org >> /etc/hosts && /opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN npm --version
 
 # The docker container is run without network access, so dont check for updates
 ENV NO_UPDATE_NOTIFIER=true
-RUN echo 127.0.0.1   registry.npmjs.org >> /etc/hosts
 
 WORKDIR /opt/test-runner
 COPY . .
@@ -15,4 +14,4 @@ RUN npm install @abaplint/cli -g
 RUN npm install @abaplint/transpiler-cli -g
 RUN npm install @abaplint/runtime -g
 RUN npm list -g
-ENTRYPOINT ["/opt/test-runner/bin/run.sh"]
+ENTRYPOINT ["echo 127.0.0.1   registry.npmjs.org >> /etc/hosts && /opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
 RUN apk add --no-cache git
+RUN npm --version
 
 # The docker container is run without network access, so dont check for updates
 ENV NO_UPDATE_NOTIFIER=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-alpine
 RUN apk add --no-cache git
 
 # The docker container is run without network access, so dont check for updates
-RUN npm config set -g update-notifier false
+ENV NO_UPDATE_NOTIFIER true
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine
+FROM node:lts-alpine
 
 RUN apk add --no-cache git
 RUN npm --version

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
+    /*
     execSync(`npm --version > _version.txt && npm link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
@@ -131,6 +132,7 @@ class Runner {
     console.log("link: " + (end - start) + "ms");
     console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
     console.dir(fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8"));
+    */
   }
 
   private executeTests() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ class Runner {
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
-    console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
+    console.dir(fs.readFileSync(path.join(this.tmpDir, "npm-debug.log"), "utf-8"));
   }
 /*
   private getGlobalPath() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,18 +129,8 @@ class Runner {
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
-    console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
+    // console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
   }
-/*
-  private getGlobalPath() {
-    execSync(`npm root -g > _version.txt`, {
-      stdio: 'pipe',
-      cwd: this.tmpDir });
-    const p = fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8").trim();
-    execSync(`cp -r ${p} ${this.tmpDir}`, {stdio: 'pipe'});
-    return p;
-  }
-  */
 
   private executeTests() {
     const start = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,13 +125,13 @@ class Runner {
     const RUN_RESULT = "_run_result.txt";
     execSync(`npm link @abaplint/runtime`, {
       stdio: 'pipe',
+      env: {'NO_UPDATE_NOTIFIER': 'true'},
       cwd: this.tmpDir });
 
     try {
 
       execSync(`node compiled/index.mjs > ` + RUN_RESULT, {
         stdio: 'pipe',
-        env: {'NO_UPDATE_NOTIFIER': 'true'},
         cwd: this.tmpDir});
     } catch (error) {
       output.status = "fail";

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --loglevel verbose link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --ignore-scripts=true link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --version && npm link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ class Runner {
     const RUN_RESULT = "_run_result.txt";
     execSync(`npm link @abaplint/runtime`, {
       stdio: 'pipe',
-      env: {...process.env, 'NO_UPDATE_NOTIFIER': 'true'},
+      env: {...process.env, 'NO_UPDATE_NOTIFIER': '1'},
       cwd: this.tmpDir });
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --version > _version.txt && npm link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --version > _version.txt && npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,10 @@ class Runner {
       cwd: this.tmpDir });
 
     try {
+
       execSync(`node compiled/index.mjs > ` + RUN_RESULT, {
         stdio: 'pipe',
+        env: {'NO_UPDATE_NOTIFIER': 'true'},
         cwd: this.tmpDir});
     } catch (error) {
       output.status = "fail";

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,18 +122,16 @@ class Runner {
   }
 
   private link() {
-    return;
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm root -g > _version.txt && npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
     console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
-    console.dir(fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8"));
   }
-
+/*
   private getGlobalPath() {
     execSync(`npm root -g > _version.txt`, {
       stdio: 'pipe',
@@ -142,12 +140,12 @@ class Runner {
     execSync(`cp -r ${p} ${this.tmpDir}`, {stdio: 'pipe'});
     return p;
   }
+  */
 
   private executeTests() {
     const start = Date.now();
     const RUN_RESULT = "_run_result.txt";
 
-    this.getGlobalPath();
     try {
       execSync(`node compiled/index.mjs > ` + RUN_RESULT, {
         stdio: 'pipe',

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ class Runner {
     const RUN_RESULT = "_run_result.txt";
     execSync(`npm link @abaplint/runtime`, {
       stdio: 'pipe',
-      env: {'NO_UPDATE_NOTIFIER': 'true'},
+      env: {...process.env, 'NO_UPDATE_NOTIFIER': 'true'},
       cwd: this.tmpDir });
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,12 +124,13 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --version && npm link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --version > _version.txt && npm link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
     console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
+    console.dir(fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8"));
   }
 
   private executeTests() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --no-update-notifier link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --fund=false link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --fund=false link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm --ignore-scripts=true link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,6 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    /*
     execSync(`npm --version > _version.txt && npm link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
@@ -132,7 +131,6 @@ class Runner {
     console.log("link: " + (end - start) + "ms");
     console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
     console.dir(fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8"));
-    */
   }
 
   private executeTests() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,12 +124,12 @@ class Runner {
   private link() {
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --loglevel verbose link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
-    console.dir(fs.readFileSync(path.join(this.tmpDir, "npm-debug.log"), "utf-8"));
+    console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
   }
 /*
   private getGlobalPath() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,12 +122,14 @@ class Runner {
   }
 
   private link() {
+    const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --no-update-notifier link @abaplint/runtime`, {
+    execSync(`npm --no-update-notifier link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();
     console.log("link: " + (end - start) + "ms");
+    console.dir(fs.readFileSync(path.join(this.tmpDir, RUN_RESULT), "utf-8"));
   }
 
   private executeTests() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,9 +122,10 @@ class Runner {
   }
 
   private link() {
+    return;
     const RUN_RESULT = "_link_result.txt";
     const start = Date.now();
-    execSync(`npm --version > _version.txt && npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
+    execSync(`npm root -g > _version.txt && npm --global-style=true link @abaplint/runtime > ` + RUN_RESULT, {
       stdio: 'pipe',
       cwd: this.tmpDir });
     const end = Date.now();
@@ -133,10 +134,20 @@ class Runner {
     console.dir(fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8"));
   }
 
+  private getGlobalPath() {
+    execSync(`npm root -g > _version.txt`, {
+      stdio: 'pipe',
+      cwd: this.tmpDir });
+    const p = fs.readFileSync(path.join(this.tmpDir, "_version.txt"), "utf-8").trim();
+    execSync(`cp -r ${p} ${this.tmpDir}`, {stdio: 'pipe'});
+    return p;
+  }
+
   private executeTests() {
     const start = Date.now();
     const RUN_RESULT = "_run_result.txt";
 
+    this.getGlobalPath();
     try {
       execSync(`node compiled/index.mjs > ` + RUN_RESULT, {
         stdio: 'pipe',

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ class Runner {
       this.transpile();
     }
     if (output.status === "pass") {
+      this.link();
       this.executeTests();
     }
     fs.writeFileSync(outputFile, JSON.stringify(output));
@@ -120,16 +121,20 @@ class Runner {
     console.log("transpile: " + (end - start) + "ms");
   }
 
+  private link() {
+    const start = Date.now();
+    execSync(`npm --no-update-notifier link @abaplint/runtime`, {
+      stdio: 'pipe',
+      cwd: this.tmpDir });
+    const end = Date.now();
+    console.log("link: " + (end - start) + "ms");
+  }
+
   private executeTests() {
     const start = Date.now();
     const RUN_RESULT = "_run_result.txt";
-    execSync(`npm link @abaplint/runtime`, {
-      stdio: 'pipe',
-      env: {...process.env, 'NO_UPDATE_NOTIFIER': '1'},
-      cwd: this.tmpDir });
 
     try {
-
       execSync(`node compiled/index.mjs > ` + RUN_RESULT, {
         stdio: 'pipe',
         cwd: this.tmpDir});


### PR DESCRIPTION
there is something strange happening in lts-alpine when running "npm link", which makes it take 10seconds

this changes to use the lts-slim docker image instead, which dramatically reduces runtime(9+ seconds reduction)