### PR TITLE
Shrink docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
-.git/
-.appends/
-.github/
-.gitattributes
-.gitignore
-Dockerfile
-bin/run-in-docker.sh
-bin/run-tests-in-docker.sh
-tests/
-output/
-open-abap/
+# Ignore everything to act as an allow list
+*
+
+# Include application files
+!bin/run.sh
+!extra/
+!src/
+!test/
+!package-lock.json
+!package.json
+!tsconfig.json

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -20,6 +20,7 @@ docker run \
     --rm \
     --network none \
     --read-only \
+    --mount type=bind,source="${PWD}/bin/run-tests.sh",destination=/opt/test-runner/bin/run-tests.sh \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
     --mount type=tmpfs,dst=/tmp \
     --workdir /opt/test-runner \


### PR DESCRIPTION
Before: 436MB, after: 187MB (57% reduction)

There are 160MB from the base `node:lts-alpine`

Missing potential savings:
- A potential improvement on our side would be to avoid having to install dependencies globally and locally (I do not know why this is necessary, but it clearly fails when we don't do this). Alternatively it is maybe possible to create a symbolic link between local and global dependencies.
- Another saving would be to extract the deps we need from the open-abap-core repository and clean it up. We could maybe even save runtime doing so by preparing the directory layout to run the tests. https://github.com/exercism/abap-test-runner/blob/af7a806a8b80948622ebaa8f72124beb281ad99b/src/index.ts#L127-L144

There are 2 commits:
1. The first one is an update to the test results that was necessary because the open-abap-core had changes
2. The second one is the one where I shrink the size